### PR TITLE
hotfix/docker_missing_setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,9 @@ COPY --from=frontend-compile /build /var/www
 # Copy existing application directory permissions
 COPY --from=frontend-compile --chown=www:www /build /var/www
 
+# Install PHP dependencies
+RUN composer install
+
 # Change current user to www
 USER www
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
             SERVICE_TAGS: dev
         working_dir: /var/www
         volumes:
-            - ./:/var/www
+            - 'appdata:/var/www'
             - ./docker/php/local.ini:/usr/local/etc/php/conf.d/local.ini
         networks:
             - app-network
@@ -30,7 +30,7 @@ services:
             - "80:80"
             - "443:443"
         volumes:
-            - ./:/var/www
+            - appdata:/var/www
             - ./docker/nginx/conf.d/:/etc/nginx/conf.d/
         networks:
             - app-network
@@ -58,6 +58,8 @@ services:
             - app-network
 
 volumes:
+    appdata:
+        driver: local
     dbdata:
         driver: local
 


### PR DESCRIPTION
Add missing setup lines to Dockerfile & docker-compose.yml. These errors were not caught while testing because the project was manually built on the host, which masked the fact that the containers weren't using the compiled files from the Dockerfile build.